### PR TITLE
Pin satdata version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Changelog
 
 
-## [v0.1.0](https://github.com/convml/convml_tt/tree/v0.1.0)
+## [Unreleased](https://github.com/convml/convml-data/tree/HEAD)
 
-[Full Changelog](https://github.com/convml/convml_tt/compare/...v0.1.0)
+[Full Changelog](https://github.com/convml/convml-data/compare/v0.1.0...HEAD)
 
-- Refactor to remove all functionality from convml_tt which doesn't involve dataset generation [\#1](https://github.com/convml/convml_data/pull/1) ([leifdenby](https://github.com/leifdenby))
+- Pin `satdata` package to version released on pypi. This is necessary to be
+  able to put `convml-data` on pypi
+  [\#14](https://github.com/convml/convml-data/pull/14)
+  ([leifdenby](https://github.com/leifdenby))
+
+
+## [v0.1.0](https://github.com/convml/convml-data/tree/v0.1.0)
+
+[Full Changelog](https://github.com/convml/convml-data/compare/...v0.1.0)
+
+- Refactor to remove all functionality from convml-data which doesn't involve
+  dataset generation [\#1](https://github.com/convml/convml-data/pull/1)
+  ([leifdenby](https://github.com/leifdenby))

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,8 +44,8 @@ sattiles =
     satpy
     esmpy
     xesmf
-    regridcart
-    satdata @ git+https://github.com/leifdenby/satdata@v0.1.3#egg=satdata
+    regridcart>=0.1.0
+    satdata>=0.2.4
 
 dev =
     ipdb


### PR DESCRIPTION
Pin satdata to specific version that has been released on pypi. This is required so that we can publish convml-data on pypi