### PR TITLE
Bugfix for triplet tile locations generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 
+## [Unreleased](https://github.com/convml/convml-data/tree/HEAD)
+
+[Full Changelog](https://github.com/convml/convml-data/compare/v0.2.0...)
+
+*bugfixes*
+
+- Fix issue where triplet tiles generated with multiple workers in parallel
+  sometimes were at repeated locations, i.e. some tiles were exactly at the
+  same locations [\#19](https://github.com/convml/convml-data/pull/19)
+
+
 ## [v0.2.0](https://github.com/convml/convml-data/tree/v0.2.0)
 
 [Full Changelog](https://github.com/convml/convml-data/compare/v0.1.0...v0.2.0)

--- a/convml_data/pipeline/tiles.py
+++ b/convml_data/pipeline/tiles.py
@@ -79,8 +79,11 @@ class SceneTileLocations(luigi.Task):
                 if isinstance(domain, sampling_domain.SourceDataDomain):
                     ds_scene = self.input()["scene_source_data"].open()
                     domain = domain.generate_from_dataset(ds=ds_scene)
+
                 tile_locations = triplets.sample_triplet_tile_locations(
-                    tiles_meta=tiles_meta, domain=domain, data_source=self.data_source
+                    tiles_meta=tiles_meta,
+                    domain=domain,
+                    data_source=self.data_source,
                 )
             elif self.tiles_kind == "trajectories":
                 tile_locations = tiles_meta

--- a/convml_data/pipeline/triplets.py
+++ b/convml_data/pipeline/triplets.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import luigi
@@ -132,11 +133,22 @@ def sample_triplet_tile_locations(tiles_meta, domain, data_source):
     tile_size = dx * tile_N
 
     tile_locations = []
-    for tile_meta in tiles_meta:
+    for n, tile_meta in enumerate(tiles_meta):
+        # to ensure that we don't get repeated tile locations generated when
+        # running with luigi (which uses multiprocessing) we need to initiate a
+        # random-number generator here while passing in the process id
+        rng_seed = (
+            os.getpid(),
+            n,
+            tile_meta["triplet_id"],
+        )
+        rng = np.random.default_rng(rng_seed)
+
         triplet_tile_locations = triplet_sampling.generate_triplet_location(
             domain=domain,
             tile_size=tile_size,
             neigh_dist_scaling=neigh_dist_scaling,
+            rng=rng,
         )
 
         tile_types = []

--- a/convml_data/sampling/triplets.py
+++ b/convml_data/sampling/triplets.py
@@ -5,7 +5,7 @@ from scipy.constants import pi
 from ..sampling import CartesianSquareTileDomain
 
 
-def generate_randomly_located_tile(domain, tile_size):
+def generate_randomly_located_tile(domain, tile_size, rng=None):
     """
     Generate a tile domain of a specific `tile_siez` that fits inside `domain`
     """
@@ -17,8 +17,11 @@ def generate_randomly_located_tile(domain, tile_size):
     d_ymin = np.min(domain_bounds[..., 1]) + tile_size / 2.0
     d_ymax = np.max(domain_bounds[..., 1]) - tile_size / 2.0
 
-    x_t = d_xmin + (d_xmax - d_xmin) * np.random.random()
-    y_t = d_ymin + (d_ymax - d_ymin) * np.random.random()
+    if rng is None:
+        rng = np.random.default_rng(rng)
+
+    x_t = d_xmin + (d_xmax - d_xmin) * rng.uniform()
+    y_t = d_ymin + (d_ymax - d_ymin) * rng.uniform()
 
     tile_domain = CartesianSquareTileDomain(x_c=x_t, y_c=y_t, size=tile_size)
     if isinstance(domain, LocalCartesianDomain):
@@ -41,14 +44,17 @@ def generate_randomly_located_tile(domain, tile_size):
 
 
 def generate_tile_domain_with_peturbed_location(
-    domain, tile_domain, tile_size, distance_size_scaling
+    domain, tile_domain, tile_size, distance_size_scaling, rng=None
 ):
     """
     Generate a tile of a specific `tile_size` that fits inside `domain`
     """
     domain_bounds_geometry = domain.spatial_bounds_geometry
 
-    theta = 2 * pi * np.random.random()
+    if rng is None:
+        rng = np.random.default_rng(rng)
+
+    theta = 2 * pi * rng.uniform()
     r = distance_size_scaling * tile_size
     dlx = r * np.cos(theta)
     dly = r * np.sin(theta)
@@ -70,21 +76,17 @@ def generate_tile_domain_with_peturbed_location(
             tile_domain=tile_domain,
             tile_size=tile_size,
             distance_size_scaling=distance_size_scaling,
+            rng=rng,
         )
 
 
-def generate_triplet_location(
-    domain,
-    tile_size,
-    neigh_dist_scaling=1.0,
-):
+def generate_triplet_location(domain, tile_size, neigh_dist_scaling=1.0, rng=None):
     """
     Generate a set of (x,y)-positions (a list of three specifically)
     representing the "anchor", "neighbor" and "distant" tile locations
     """
-
     anchor_tile_domain = generate_randomly_located_tile(
-        domain=domain, tile_size=tile_size
+        domain=domain, tile_size=tile_size, rng=rng
     )
 
     neighbor_tile_domain = generate_tile_domain_with_peturbed_location(
@@ -92,9 +94,10 @@ def generate_triplet_location(
         tile_domain=anchor_tile_domain,
         tile_size=tile_size,
         distance_size_scaling=neigh_dist_scaling,
+        rng=rng,
     )
     distant_tile_domain = generate_randomly_located_tile(
-        domain=domain, tile_size=tile_size
+        domain=domain, tile_size=tile_size, rng=rng
     )
 
     return [anchor_tile_domain, neighbor_tile_domain, distant_tile_domain]


### PR DESCRIPTION
Fix issue where positions for generated tiles were sometimes repeated
when using luigi to run the tile creation pipeline across multiple
processors in parallel.  This issue was due to the random number
generator state being the same across all processes and so the positions
generated were the same. This commits fixes this issue by creating a
random number generator seed using the processor id.