### PR TITLE
Pipeline queries return timestamp with files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: check-yaml
   # isort should run before black as black sometimes tweaks the isort output
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   # https://github.com/python/black#version-control-integration

--- a/convml_data/pipeline/scene_sources.py
+++ b/convml_data/pipeline/scene_sources.py
@@ -1,13 +1,11 @@
 import datetime
-import itertools
 import logging
-from functools import partial
 from pathlib import Path
 
 import luigi
 
 from .. import DataSource
-from ..sources import build_query_tasks, get_time_for_filename
+from ..sources import build_query_tasks
 from ..utils.luigi import DBTarget
 
 log = logging.getLogger()
@@ -30,34 +28,30 @@ def parse_scene_id(s):
     return source, datetime.datetime.strptime(t_str, SCENE_ID_DATE_FORMAT)
 
 
-def merge_multiinput_sources(files_per_input, time_fn):
-    input_files_by_timestamp = {}
-    N_inputs = len(files_per_input)
-    for input_name, input_files in files_per_input.items():
-        for input_filename in input_files:
-            file_timestamp = time_fn(filename=input_filename)
-            time_group = input_files_by_timestamp.setdefault(file_timestamp, {})
+def merge_multiinput_sources(all_files_by_part_and_time):
+    input_files_grouped_by_timestamp = {}
+    N_inputs = len(all_files_by_part_and_time)
+
+    for input_name, input_parts in all_files_by_part_and_time.items():
+        for file_timestamp, input_filename in input_parts.items():
+            time_group = input_files_grouped_by_timestamp.setdefault(file_timestamp, {})
             time_group[input_name] = input_filename
 
-    scene_filesets = []
+    all_timestamps = sorted(list(input_files_grouped_by_timestamp.keys()))
 
-    for timestamp in sorted(input_files_by_timestamp.keys()):
-        timestamp_files = input_files_by_timestamp[timestamp]
+    for timestamp in all_timestamps:
+        timestamp_files = input_files_grouped_by_timestamp[timestamp]
 
         if len(timestamp_files) == N_inputs:
-            scene_filesets.append(
-                {
-                    input_name: timestamp_files[input_name]
-                    for input_name in files_per_input.keys()
-                }
-            )
+            pass
         else:
             log.warn(
                 f"Only {len(timestamp_files)} were found for timestamp {timestamp}"
                 " so this timestamp will be excluded"
             )
+            del input_files_grouped_by_timestamp[timestamp]
 
-    return scene_filesets
+    return input_files_grouped_by_timestamp
 
 
 def create_scenes_from_input_queries(inputs, source_name, product):
@@ -68,32 +62,35 @@ def create_scenes_from_input_queries(inputs, source_name, product):
     timestamp for each scene (returned as as a dictionary of times, with each
     entry being a dictionary of the input-name -> filename for that scene)
     """
-    scenes_by_time = {}
-
-    opened_inputs = {}
+    all_files_by_part_and_time = {}
     for input_name, input_parts in inputs.items():
         # some queries return a list of DBTargets each containing a number of
         # filenames matching the queries, some only return a single DBTarget,
         # so we make into a list here to handle the general case
+
+        input_part_files_by_time = {}
+
         if not isinstance(input_parts, list):
             input_parts = [input_parts]
 
-        opened_inputs[input_name] = list(
-            itertools.chain(*[input_part.open() for input_part in input_parts])
-        )
+        for input_part in input_parts:
+            files_by_time = input_part.open()
+            if not isinstance(files_by_time, dict):
+                raise Exception(
+                    f"The query-result database for `{product}` is in the old format"
+                    " (without the timestamp for each file). Please delete `{input_part.path}`"
+                    " and rerun this task."
+                )
 
-    time_fn = partial(get_time_for_filename, source_name=source_name)
+            input_part_files_by_time.update(files_by_time)
 
-    scene_sets = merge_multiinput_sources(opened_inputs, time_fn=time_fn)
+        all_files_by_part_and_time[input_name] = input_part_files_by_time
 
-    # use the first input to work out what time to use for the whole combined
-    # product for the scene
-    input_name_timing = list(inputs.keys())[0]
-    for scene_filenames in scene_sets:
-        t_scene = time_fn(filename=scene_filenames[input_name_timing])
-        scenes_by_time[t_scene] = scene_filenames
+    scene_files_by_time = merge_multiinput_sources(
+        all_files_by_part_and_time=all_files_by_part_and_time
+    )
 
-    return scenes_by_time
+    return scene_files_by_time
 
 
 class GenerateSceneIDs(luigi.Task):
@@ -129,11 +126,14 @@ class GenerateSceneIDs(luigi.Task):
         if type(input) == dict:
             # multi-channel queries, each channel is represented by a key in the
             # dictionary
-            scenes_by_time = create_scenes_from_input_queries(
-                inputs=self.input(),
-                source_name=self.data_source.source,
-                product=self.data_source.product,
-            )
+            import ipdb
+
+            with ipdb.launch_ipdb_on_exception():
+                scenes_by_time = create_scenes_from_input_queries(
+                    inputs=self.input(),
+                    source_name=self.data_source.source,
+                    product=self.data_source.product,
+                )
         else:
             raise NotImplementedError(input)
 

--- a/convml_data/sources/__init__.py
+++ b/convml_data/sources/__init__.py
@@ -213,24 +213,6 @@ def get_user_function_source_input_names(source_name, product_meta):
     return input_names
 
 
-def get_time_for_filename(source_name, filename):
-    """Return the timestamp for a given source data file"""
-    if source_name == "goes16":
-        t = GOES16Query.get_time(filename=filename)
-    elif source_name == "LES":
-        t = FindLESFiles.get_time(filename=filename)
-    elif source_name == "ceres_geo":
-        t = ceres_geo.pipeline.QueryForData.get_time(filename=filename)
-    elif source_name == "ceres_syn1deg_modis":
-        t = ceres_syn1deg_modis.pipeline.QueryForData.get_time(filename=filename)
-    elif source_name == "era5":
-        t = era5.pipeline.ERA5Query.get_time(filename=filename)
-    else:
-        raise NotImplementedError(source_name)
-
-    return t
-
-
 def _extract_scene_data_for_user_function(task_input, product_meta, bbox_crop):
     das = []
 

--- a/convml_data/sources/ceres_geo/pipeline.py
+++ b/convml_data/sources/ceres_geo/pipeline.py
@@ -23,7 +23,7 @@ class QueryForData(luigi.Task):
                 f"Couldn't parse data-type `{self.data_type}`, please make sure"
                 " it has the format `{satellite}__{product_name}`"
             ) from ex
-        filenames = list(
+        filenames = dict(
             get_available_files(
                 t_start=self.t_start, t_end=self.t_end, satellite=satellite
             )

--- a/convml_data/sources/ceres_geo/query.py
+++ b/convml_data/sources/ceres_geo/query.py
@@ -49,5 +49,5 @@ def get_available_files(t_start, t_end, satellite):
     while t < t_end:
         fn = make_local_filename(time=t, satellite=satellite)
         if t.strftime(TIME_FORMAT) not in MISSING_TIMES.get(satellite, []):
-            yield fn
+            yield (t, fn)
         t += datetime.timedelta(hours=1)

--- a/convml_data/sources/ceres_syn1deg_modis/pipeline.py
+++ b/convml_data/sources/ceres_syn1deg_modis/pipeline.py
@@ -16,7 +16,7 @@ class QueryForData(luigi.Task):
     DB_NAME_FORMAT = "keys_{t_start:%Y%m%d%H%M}_{t_end:%Y%m%d%H%M}"
 
     def run(self):
-        filenames = list(get_available_files(t_start=self.t_start, t_end=self.t_end))
+        filenames = dict(get_available_files(t_start=self.t_start, t_end=self.t_end))
 
         Path(self.output().fn).parent.mkdir(exist_ok=True, parents=True)
         self.output().write(filenames)

--- a/convml_data/sources/ceres_syn1deg_modis/query.py
+++ b/convml_data/sources/ceres_syn1deg_modis/query.py
@@ -34,4 +34,4 @@ def get_available_files(t_start, t_end):
             for time in times:
                 if t_start <= time <= t_end:
                     filename = url.split("/")[-1]
-                    yield filename
+                    yield (time, filename)

--- a/convml_data/sources/era5/pipeline.py
+++ b/convml_data/sources/era5/pipeline.py
@@ -49,7 +49,7 @@ def get_available_files(t_start, t_end, product):
 
     t = t0
     while t < t_end:
-        yield str(_make_filepath(t=t, var=product))
+        yield (t, str(_make_filepath(t=t, var=product)))
         t += datetime.timedelta(hours=1)
 
 
@@ -76,7 +76,7 @@ class ERA5Query(luigi.Task):
             raise Exception(
                 f"{self.data_type} is not one of the available source variables"
             )
-        filenames = list(
+        filenames = dict(
             get_available_files(
                 t_start=self.t_start, t_end=self.t_end, product=self.data_type
             )

--- a/convml_data/sources/goes16/pipeline.py
+++ b/convml_data/sources/goes16/pipeline.py
@@ -48,9 +48,12 @@ class GOES16Query(luigi.Task):
         filenames = cli.query(
             time=self.time, region="F", debug=self.debug, dt_max=self.dt_max, **kws
         )
+        times_and_files = {
+            self.parse_filename(fn)["start_time"]: fn for fn in filenames
+        }
 
         Path(self.output().fn).parent.mkdir(exist_ok=True, parents=True)
-        self.output().write(filenames)
+        self.output().write(times_and_files)
 
     def output(self):
         if self.channel is not None:

--- a/tests/example/meta.yaml
+++ b/tests/example/meta.yaml
@@ -2,7 +2,7 @@ source: goes16
 product: truecolor_rgb
 
 aux_products:
-  cloud_top_temperature:
+  cloud_top_temperature_ceres_geo:
     source: ceres_geo
     product: goes16n__cloud_top_temperature
   total_net_radiation:


### PR DESCRIPTION
Simplify data source queries by storing the timestamp(s) that each file contains. If a single file contains multiple times the query database will contain multiple entries for the same file.